### PR TITLE
Remove redudant rule for neg integers

### DIFF
--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -128,9 +128,6 @@ rule row = parse
   | '-' positive_int
       { NEG_INT (extract_negative_int lexbuf) }
 
-  | '-' positive_int
-      { NEG_INT (extract_negative_int lexbuf) }
-
   | float
       { float_or_int_of_string (lexeme lexbuf) }
 


### PR DESCRIPTION
The lexer contains the same rule for negative integers twice. Remove one.